### PR TITLE
fix(version): gitlab-runner updated to `17.2.1` release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Role Variables
 - `gitlab_runner_package_version` The version of the GitLab Runner package. By default, GitLab Runner is installed with the latest available version.
 - `gitlab_runner_repository_mirror_url` The GitLab repository mirror (default: `https://packages.gitlab.com/runner/gitlab-runner`).
 - `gitlab_runner_repository_gpgkey_url` URL to GitLab repository GPG key file (default: `https://packages.gitlab.com/runner/gitlab-runner/gpgkey`).
-- `gitlab_runner_binary_version` The version of the GitLab Runner binary (default: `17.2.0`).
+- `gitlab_runner_binary_version` The version of the GitLab Runner binary (default: `17.2.1`).
 - `gitlab_runner_binary_name` The GitLab Runner binary name (default: `gitlab-runner-windows-amd64`).
-- `gitlab_runner_download_url` URL to download the GitLab Runner binary (default: `https://gitlab-runner-downloads.s3.amazonaws.com/v17.2.0/binaries`).
+- `gitlab_runner_download_url` URL to download the GitLab Runner binary (default: `https://gitlab-runner-downloads.s3.amazonaws.com/v17.2.1/binaries`).
 - `gitlab_runner_download_path` Local path to download and extract the binary (default: `/tmp`).
 - `gitlab_runner_install_path` GitLab Runner installation folder (default: `C:\Program Files\gitlab-runner`).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ gitlab_runner_repository_gpgkey_url: '{{ gitlab_runner_repository_mirror_url }}/
 
 # Install GitLab Runner using the binary file (Windows)
 ## See available releases: https://gitlab.com/gitlab-org/gitlab-runner/-/releases
-gitlab_runner_binary_version: '17.2.0'
+gitlab_runner_binary_version: '17.2.1'
 gitlab_runner_binary_name: 'gitlab-runner-{{ _gitlab_runner_os }}-{{ _gitlab_runner_architecture }}'
 gitlab_runner_download_url: 'https://gitlab-runner-downloads.s3.amazonaws.com/v{{ gitlab_runner_binary_version }}/binaries'
 gitlab_runner_download_path: '/tmp'


### PR DESCRIPTION
The upstream GitLab Runner has released a new software version - **17.2.1**!

See [the changelog](https://gitlab.com/gitlab-org/gitlab-runner/blob/v17.2.1/CHANGELOG.md) :rocket:

GitLab Runner documentation can be found at https://docs.gitlab.com/runner/.

This automated PR updates code to bring new version into repository.