### PR TITLE
fix(version): gitlab-runner updated to `17.7.0` release

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ gitlab_runner_repository: '{{ __gitlab_runner_repository }}'
 
 # Install GitLab Runner using the binary file (Windows and MacOSX)
 ## See available releases: https://gitlab.com/gitlab-org/gitlab-runner/-/releases
-gitlab_runner_binary_version: '17.6.0'
+gitlab_runner_binary_version: '17.7.0'
 gitlab_runner_binary_name: 'gitlab-runner-{{ __gitlab_runner_binary_os }}-{{ __gitlab_runner_binary_architecture }}'
 gitlab_runner_binary_download_url: 'https://gitlab-runner-downloads.s3.amazonaws.com/v{{ gitlab_runner_binary_version }}/binaries'
 gitlab_runner_binary_download_path: '/tmp'

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -30,7 +30,7 @@ argument_specs:
       gitlab_runner_binary_version:
         type: 'str'
         description: 'The version of the GitLab Runner binary.'
-        default: '17.6.0'
+        default: '17.7.0'
       gitlab_runner_binary_name:
         type: 'str'
         description: 'The GitLab Runner binary name.'


### PR DESCRIPTION
The upstream GitLab Runner has released a new software version - **17.7.0**!

See [the changelog](https://gitlab.com/gitlab-org/gitlab-runner/blob/v17.7.0/CHANGELOG.md) :rocket:

GitLab Runner documentation can be found at https://docs.gitlab.com/runner/.

This automated PR updates code to bring new version into repository.